### PR TITLE
fs-ci: open branch's CI page in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,21 @@ $ fs gh show <commit_id>             # opens commit <commit_id> on github
 alias pr='fs gh p'
 ```
 
+### `fs ci`
+
+Open branch's CI page in browser
+
+```bash
+
+$ fs ci            # opens current branch on CI service
+$ fs ci master     # opens "master" branch on CI service
+```
+
+**PRO tip:** Another killer feature here:
+```bash
+alias ci='fs ci'
+```
+
 ### `fs new` (`fs bootstrap`)
 
 Bootstrap new project from fs/xxx-base templates

--- a/libexec/fs-ci
+++ b/libexec/fs-ci
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 set -e
 # Usage: fs ci [<branch>]
-# Summary: Open branch CI page in browser
-# Help: This can be used to open current branch (or any specified branch) on CI (Semaphore)
+# Summary: Open branch's CI page in browser
+# Help: This can be used to open current branch (or any specified branch) on CI service (Semaphore)
 # Requires `ci` parameter to be set in `.fs.yml`.
 # Examples:
 #
-#    fs ci            # opens current branch on CI
-#    fs ci master     # opens "master" branch on CI
+#    fs ci            # opens current branch on CI service
+#    fs ci master     # opens "master" branch on CI service
 
 case $1 in
   "" )

--- a/libexec/fs-init-config
+++ b/libexec/fs-init-config
@@ -23,6 +23,7 @@ USER=$(whoami)
 export USER ROOT_DIR PROJECT_NAME
 
 cat <<EOF > $ROOT_DIR/.fs.yml
+ci: "https://semaphoreapp.com/$USER/$PROJECT_NAME/branches/%{branch}"
 servers:
   staging:
     address: $USER@staging.$PROJECT_NAME.com


### PR DESCRIPTION
Requires additional configuration in project's `.fs.yml`:

``` yaml
# .fs.yml
ci: "https://semaphoreapp.com/fs/rails-base/branches/%{branch}"
```

TODO:
- [x] docs
- [x] autocomplete branch name
- [x] error when CI URL is not set in `.fs.yml` (or it even doesn't exist)
