### PR TITLE
Update links to fs guides

### DIFF
--- a/share/fs/guides.yml
+++ b/share/fs/guides.yml
@@ -13,6 +13,8 @@ paths:
   bug_report: developing/bug-reporting-format
   pairing: developing/pair-programming
   pair_programming: developing/pair-programming
+  continuous_deployment: developing/continuous-deployment
+  deployment: developing/continuous-deployment
   style: best-practices
   style_guide: best-practices
   best_practices: best-practices


### PR DESCRIPTION
- Add separate links to ec2 & s3 instead of aws
- Add pair programming, EY and pivotal tracker links

@vast feel free to update this if you find any useful sections from guides
